### PR TITLE
Don't allow to add clone path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 install:
-		go install
+		@go install
 
 build:
-		go build 
+		@go build 
 
-test:
-		go test ./...
+unit-test: 
+		@go test -v ./...

--- a/main.go
+++ b/main.go
@@ -58,12 +58,12 @@ func init() {
 	diff.Flags().StringVarP(&base, "base", "b", "master", "branch to be used, as the base, in the comparison of the diff in the monorepo")
 	diff.Flags().StringVarP(&compare, "compare", "c", "", "branch to be used to compare with the base in the monorepo")
 	diff.MarkFlagRequired("compare")
-	diff.MarkFlagRequired("local")
+	diff.MarkFlagRequired("services")
 
 	services = cmd.Services()
 	assignFlags(services.Flags())
 	services.Flags().StringVarP(&ref, "branch", "b", "master", "branch to be used for the summary of all services in the monorepo")
-	diff.MarkFlagRequired("local")
+	services.MarkFlagRequired("services")
 }
 
 func main() {
@@ -139,21 +139,19 @@ func loadConfig(config string, m *mono.Config, r *RepoConfig) error {
 	repoConfig.URL = url
 	repoConfig.Path = local
 
-	if config == "" {
-		return nil
-	}
+	if config != "" {
+		d, err := ioutil.ReadFile(config)
+		if err != nil {
+			return err
+		}
 
-	d, err := ioutil.ReadFile(config)
-	if err != nil {
-		return err
-	}
+		if err := json.Unmarshal(d, m); err != nil {
+			return err
+		}
 
-	if err := json.Unmarshal(d, m); err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(d, r); err != nil {
-		return err
+		if err := json.Unmarshal(d, r); err != nil {
+			return err
+		}
 	}
 
 	if repoConfig.URL == "" && repoConfig.Path == "" {
@@ -211,7 +209,7 @@ func getMeta(mCfg mono.Config, rCfg RepoConfig) (*mono.Meta, repo.Repository, er
 			return nil, nil, err
 		}
 	} else {
-		r, err = repo.NewRemote(rCfg.URL, rCfg.Path)
+		r, err = repo.NewRemote(rCfg.URL)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
+const tempDir = "/tmp/monorepo"
+
 // Repository is an interface
 type Repository interface {
 	Checkout(ref string) (string, error)
@@ -28,15 +30,15 @@ type local struct {
 }
 
 // NewRemote clones a remote git repository
-func NewRemote(url, path string) (Repository, error) {
-	r, err := git.PlainClone(path, false, &git.CloneOptions{
+func NewRemote(url string) (Repository, error) {
+	r, err := git.PlainClone(tempDir, false, &git.CloneOptions{
 		URL: url,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &remote{repo: r, path: path}, nil
+	return &remote{repo: r, path: tempDir}, nil
 }
 
 func (r *remote) LocalPath() string {


### PR DESCRIPTION
Always clone to /tmp to avoid any issues occurring with
removing repo - might accidentally remove other files